### PR TITLE
fix for graphs not showing for some stations

### DIFF
--- a/app/src/main/java/com/feer/windcast/WindGraph.java
+++ b/app/src/main/java/com/feer/windcast/WindGraph.java
@@ -62,7 +62,10 @@ public class WindGraph
                 "");                             // Set the display title of the series
 
 
-        plot.setDomainBoundaries(numObs-11, numObs-1, BoundaryMode.FIXED);
+        final int lastReadingIndex = numObs -1;
+        final int numberOfReadingsToShow = Math.min(10, lastReadingIndex);
+        final int firstReadingIndex = lastReadingIndex - numberOfReadingsToShow;
+        plot.setDomainBoundaries(firstReadingIndex, lastReadingIndex, BoundaryMode.FIXED);
         plot.setDomainStepValue(1.0);
         plot.setDomainStepMode(XYStepMode.INCREMENT_BY_VAL);
 


### PR DESCRIPTION
Where stations have less than 11 datapoints, the graph is unable to draw. This is fixed by setting the min / max index to graph based on the number of data points
